### PR TITLE
Add lore for setting up a dev environment

### DIFF
--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -1,2 +1,7 @@
 # Getting Started
-Check back soon for documentation on getting started with BonnyCI!
+
+## Set up a development environment
+
+We'll need to install some basic software to get a good foundation for contributing to BonnyCI.
+    - If you are running Ubuntu, follow the steps [here](dev-environment/ubuntu.md).
+    - If you are running macOS, follow the steps [here](dev-environment/macOS.md).

--- a/getting_started/dev-environment/macOS.md
+++ b/getting_started/dev-environment/macOS.md
@@ -1,0 +1,52 @@
+# Instructions for macOS
+
+Install required software:
+- [Homebrew](http://brew.sh/)
+- [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+- [Vagrant](https://www.vagrantup.com/downloads.html)
+
+Install ansible, basic command line tools and nodejs:
+
+```shell
+$ brew install ansible
+$ brew install coreutils
+$ brew install node
+```
+
+You can get by with coreutils with prefixing commands you want with a `g`. For instance, `rm` would be `grm`. If you don't want to think about that too much, add the following to your `~/.bash_profile`:
+
+```shell
+export PATH=/usr/local/opt/coreutils/libexec/gnubin:/usr/local/sbin:$PATH
+export MANPATH=/usr/local/opt/coreutils/libexec/gnuman:$MANPATH
+```
+
+Install the python package manager pip:
+
+```shell
+$ curl https://bootstrap.pypa.io/get-pip.py | python
+```
+
+Install setuptools, virtualenv and virtualenvwrapper:
+
+```shell
+$ sudo pip install setuptools virtualenv virtualenvwrapper
+```
+
+Add the following to your `~/.bash_profile`:
+
+```shell
+export WORKON_HOME=~/virtualenvs
+source /usr/local/bin/virtualenvwrapper.sh
+```
+
+Enable virtualenvwrapper:
+
+```shell
+$ source ~/.bash_profile
+```
+
+Install [vagrant-hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager), and [vagrant-triggers](https://github.com/emyl/vagrant-triggers):
+
+```shell
+$ vagrant plugin install vagrant-hostmanager vagrant-triggers
+```

--- a/getting_started/dev-environment/ubuntu.md
+++ b/getting_started/dev-environment/ubuntu.md
@@ -1,0 +1,39 @@
+# Instructions for Ubuntu
+
+Run the following to install most of the needed packages:
+
+```shell
+$ sudo apt-get install python-dev build-essential python-software-properties python-pip vagrant virtualbox
+```
+
+Install [vagrant-hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager), and [vagrant-triggers](https://github.com/emyl/vagrant-triggers):
+
+```shell
+$ vagrant plugin install vagrant-hostmanager vagrant-triggers
+```
+
+Add the official nodejs ppa, then install nodejs and its package manager, npm:
+
+```shell
+$ curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
+$ sudo apt-get install nodejs
+```
+
+Install ansible, setuptools, virtualenv and virtualenvwrapper:
+
+```shell
+$ sudo pip install ansible setuptools virtualenv virtualenvwrapper
+```
+
+Add the following to your `~/.bashrc`:
+
+```shell
+export WORKON_HOME=~/.virtualenvs
+. /usr/local/bin/virtualenvwrapper.sh
+```
+
+Activate virtualenvwrapper:
+
+```shell
+$ source ~/.bashrc
+```


### PR DESCRIPTION
This adds some documentation for getting a new BonnyCI contributor's
machine set up to work with all of our repos. It assumes that the
machine is relatively bare, and only provides instructions for macOS
and Ubuntu at this time.

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>