### PR TITLE
Add shellcheck to lint shell scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,19 @@ cache:
 language: python
 python: '2.7'
 
+addons:
+  apt:
+    sources:
+      - debian-sid
+    packages:
+      - shellcheck
+
 matrix:
   fast_finish: true
 
 env:
   - TEST_RUN="tests/textlint-test.sh"
+  - TEST_RUN="tests/shellcheck-test.sh"
   - TEST_RUN="tests/signed-off-by-test.sh"
 
 install:

--- a/tests/shellcheck-test.sh
+++ b/tests/shellcheck-test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+find . -name '*.sh' -print0 | xargs -n1 -0 shellcheck -s bash


### PR DESCRIPTION
Now, all scripts in the tests directory are linted for best practices.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>