### PR TITLE
Fix textlint-test.sh for best practices

### DIFF
--- a/tests/textlint-test.sh
+++ b/tests/textlint-test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-find . -name '*.md' -print | xargs -n1 textlint -c .textlintrc.js -f pretty-error
+find . -name '*.md' -print0 | xargs -n1 -0 textlint -c .textlintrc.js -f pretty-error


### PR DESCRIPTION
When using find and xargs, it is important to use `find -print0` and
`xargs -0` so that filenames including a space or newline get picked up.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>