### PR TITLE
Fix links in Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BonnyCI Documentation
-[![Build Status](https://travis-ci.org/BonnyCI/docs.svg?branch=master)](https://travis-ci.org/BonnyCI/docs)
+[![Build Status](https://travis-ci.org/BonnyCI/lore.svg?branch=master)](https://travis-ci.org/BonnyCI/lore)
 
 ## Table of Contents
 - [Introduction](#introduction)


### PR DESCRIPTION
After the repository name was changed, the old links went dead. Now they
are revitalized!

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>