### PR TITLE
Fix indentation in getting_started/README.md

### DIFF
--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -3,5 +3,5 @@
 ## Set up a development environment
 
 We'll need to install some basic software to get a good foundation for contributing to BonnyCI.
-    - If you are running Ubuntu, follow the steps [here](dev-environment/ubuntu.md).
-    - If you are running macOS, follow the steps [here](dev-environment/macOS.md).
+  * If you are running Ubuntu, follow the steps [here](dev-environment/ubuntu.md).
+  * If you are running macOS, follow the steps [here](dev-environment/macOS.md).


### PR DESCRIPTION
The bullet points for each OS were formatted all on one line, which
looks pretty gross.

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>