### PR TITLE
Add textlint dead link rule to CI checks

### DIFF
--- a/.textlintrc.js
+++ b/.textlintrc.js
@@ -1,18 +1,20 @@
 "use strict"
 module.exports = {
   "rules": {
-    "no-todo": {
-    },
-    "no-empty-section": {
+    "alex": {
     },
     "common-misspellings": {
       "ignore": []
     },
-    "alex": {
+    "no-dead-link": {
+    },
+    "no-empty-section": {
     },
     "rousseau": {
       "ignoreTypes": [],
       "showLevels": ["suggestion", "warning", "error"]
+    },
+    "no-todo": {
     }
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,9 @@ env:
 install:
   - nvm install stable
   - nvm use stable
-  - npm install -g textlint textlint-plugin-markdown textlint-rule-no-todo textlint-rule-no-empty-section
-    textlint-rule-common-misspellings textlint-rule-alex textlint-rule-rousseau
+  - npm install -g textlint textlint-rule-alex textlint-rule-common-misspellings
+    textlint-rule-no-dead-link textlint-rule-no-empty-section
+    textlint-rule-rousseau textlint-rule-no-todo
 
 script: "$TEST_RUN"
 


### PR DESCRIPTION
Added textlint-rule-no-dead-link to CI configuration. Now all lore will
be checked for dead links (and CI will fail if one is found).

In the process, textlint rules were reordered to be alphabetical.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>