### PR TITLE
Add IRC information to developer lore

### DIFF
--- a/developers/README.md
+++ b/developers/README.md
@@ -6,33 +6,32 @@
   - [Virtual Machine](#virtual-machine)
   - [Docker](#docker)
 - [Contributing](#contributing)
+- [IRC](#irc)
 
 ## Development Environment
-
 Before hacking on BonnyCI, we'll need to set up a development environment. There are three basic ways to do so:
   1. [On our local machine](#local-environment)
   2. [In a virtual machine](#virtual-machine)
   3. [In a Docker container](#docker)
 
 ### Local Environment
-
 Supported development platforms:
   - [Ubuntu](dev-environment/ubuntu.md)
   - [Apple's macOS](dev-environment/macOS.md)
 
 ### Virtual Machine
-
 Documentation coming soon...
 
 ### Docker
-
 Documentation coming later...
 
 ## Contributing
-
 Please see the [contributing documentation](contributing) for more information.
 
 A brief note on repository naming...
 > The puns get made, or the plank gets walked.
 >
 > ~Jesse Keating
+
+## IRC
+For discussions about BonnyCI, join us on [freenode](https://freenode.net) #BonnyCi!


### PR DESCRIPTION
Now developers/README.md includes a section for finding #BonnyCI on
freenode.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>