### PR TITLE
Fix location of .virtualenvs dir in macOS.md

### DIFF
--- a/developers/dev-environment/macOS.md
+++ b/developers/dev-environment/macOS.md
@@ -34,7 +34,7 @@ $ sudo pip install ansible setuptools virtualenv virtualenvwrapper
 Add the following to your `~/.bash_profile`:
 
 ```shell
-export WORKON_HOME=~/virtualenvs
+export WORKON_HOME=~/.virtualenvs
 source /usr/local/bin/virtualenvwrapper.sh
 ```
 


### PR DESCRIPTION
Previously, the documentation called for the user to set their dir for
virtualenvs to `~/virtualenvs` rather than `~/.virtualenvs`. This will
fix that typo.

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>