### PR TITLE
Fix lore for installing ubuntu dependencies

### DIFF
--- a/developers/dev-environment/ubuntu.md
+++ b/developers/dev-environment/ubuntu.md
@@ -3,7 +3,7 @@
 Run the following to install most of the needed packages:
 
 ```shell
-$ sudo apt-get install python-dev build-essential python-software-properties python-pip vagrant virtualbox
+$ sudo apt-get install build-essential libssl-dev libffi-dev python-dev python-pip python-software-properties vagrant virtualbox
 ```
 
 Install [vagrant-hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager), and [vagrant-triggers](https://github.com/emyl/vagrant-triggers):


### PR DESCRIPTION
Pip requires a few dependencies that do not get automatically installed
as dependencies for `python-pip`. This will update the docs for a
smooth installation.

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>