### PR TITLE
Set ALEX textlint rule to warning

### DIFF
--- a/.textlintrc.js
+++ b/.textlintrc.js
@@ -2,6 +2,7 @@
 module.exports = {
   "rules": {
     "alex": {
+      "severity" : "warning"
     },
     "common-misspellings": {
       "ignore": []


### PR DESCRIPTION
Previously, failures in the ALEX textlint rule would cause failures in
CI. Now we still receive warnings for things ALEX finds, but builds
pass.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>