### PR TITLE
Fix Markdown syntax before adding markdownlint-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # BonnyCI Documentation
+
 [![Build Status](https://travis-ci.org/BonnyCI/lore.svg?branch=master)](https://travis-ci.org/BonnyCI/lore)
 
 ## Table of Contents
-- [Introduction](#introduction)
-- [End Users](#end-users)
-- [Developers](#developers)
+
+* [Introduction](#introduction)
+* [End Users](#end-users)
+* [Developers](#developers)
 
 ## Introduction
+
 BonnyCI is a Continuous Integration service offered to developers of Open Source projects.
 
 ## End Users
+
 Please see the [end user documentation](end_users) for more information.
 
 ## Developers
+
 Please see the [developer documentation](developers) for more information.

--- a/developers/README.md
+++ b/developers/README.md
@@ -1,31 +1,39 @@
 # Developers
 
 ## Table of Contents
-- [Development Environment](#development-environment)
-  - [Local Environment](#local-environment)
-  - [Virtual Machine](#virtual-machine)
-  - [Docker](#docker)
-- [Contributing](#contributing)
-- [IRC](#irc)
+
+* [Development Environment](#development-environment)
+  * [Local Environment](#local-environment)
+  * [Virtual Machine](#virtual-machine)
+  * [Docker](#docker)
+* [Contributing](#contributing)
+* [IRC](#irc)
 
 ## Development Environment
+
 Before hacking on BonnyCI, we'll need to set up a development environment. There are three basic ways to do so:
+
   1. [On our local machine](#local-environment)
   2. [In a virtual machine](#virtual-machine)
   3. [In a Docker container](#docker)
 
 ### Local Environment
+
 Supported development platforms:
-  - [Ubuntu](dev-environment/ubuntu.md)
-  - [Apple's macOS](dev-environment/macOS.md)
+
+* [Ubuntu](dev-environment/ubuntu.md)
+* [Apple's macOS](dev-environment/macOS.md)
 
 ### Virtual Machine
+
 Documentation coming soon...
 
 ### Docker
+
 Documentation coming later...
 
 ## Contributing
+
 Please see the [contributing documentation](contributing) for more information.
 
 A brief note on repository naming...
@@ -34,4 +42,5 @@ A brief note on repository naming...
 > ~Jesse Keating
 
 ## IRC
+
 For discussions about BonnyCI, join us on [freenode](https://freenode.net) #BonnyCi!

--- a/developers/contributing/DEVELOPER_AGREEMENT.txt
+++ b/developers/contributing/DEVELOPER_AGREEMENT.txt
@@ -1,4 +1,3 @@
-```
 Developer's Certificate of Origin 1.1
 -------------------------------------
 
@@ -26,4 +25,3 @@ By making a contribution to this project, I certify that:
             personal information I submit with it, including my sign-off) is
             maintained indefinitely and may be redistributed consistent with
             this project or the open source license(s) involved.
-```

--- a/developers/contributing/README.md
+++ b/developers/contributing/README.md
@@ -1,26 +1,31 @@
 # Contributing
 
 ## Table of Contents
-- [BonnyCI Workflow](#bonnyci-workflow)
-- [Commits](#commits)
-  - [Commit Message](#commit-message)
-    - [Sign-off](#sign-off)
-- [Pull Requests](#pull-requests)
-- [Design Documents](#design-documents)
+
+* [BonnyCI Workflow](#bonnyci-workflow)
+* [Commits](#commits)
+  * [Commit Message](#commit-message)
+    * [Sign-off](#sign-off)
+* [Pull Requests](#pull-requests)
+* [Design Documents](#design-documents)
 
 ## BonnyCI Workflow
+
 We use the [GitHub flow](https://guides.github.com/introduction/flow/) for code changes.
 
 ## Commits
+
 Changes should include small commits that produce a functional tree. Doing so helps keep the repository history clear and simple to bisect.
 
 ### Commit Message
+
 Please keep commit messages concise and informative. If the commit relates to an open issue, please include a line in the commit message such as `Fixes #XXX`. When in doubt, follow [this guide](http://chris.beams.io/posts/git-commit/) on writing commit messages.
 
 #### Sign-off
-To improve tracking of who did what, all commits must have a "sign-off". This sign-off is a line at the end of the commit message certifying that you have read and agreed to the [Developers' Agreement](DEVELOPER_AGREEMENT.md). Certify that you agree by adding a sign-off to your commit (**NOTE:** use your real name, please):
 
-```
+To improve tracking of who did what, all commits must have a "sign-off". This sign-off is a line at the end of the commit message certifying that you have read and agreed to the [Developers' Agreement](DEVELOPER_AGREEMENT.txt). Certify that you agree by adding a sign-off to your commit (**NOTE:** use your real name, please):
+
+```text
 Signed-off-by: Random J Developer <random@developer.example.org>
 ```
 
@@ -32,17 +37,15 @@ $ git commit -s
 ```
 
 ## Pull Requests
-Pull requests start and frame a conversation. As such, it is not necessary to ask permission (or open an issue, or write a spec/blueprint) before presenting code.
 
+Pull requests start and frame a conversation. As such, it is not necessary to ask permission (or open an issue, or write a spec/blueprint) before presenting code.
 
 Anyone may review or comment on pull requests, but a member of the BonnyCI Captains team must approve it before merging.
 
-
 If a pull request is a work in progress, please start the title with `[WIP]`. It is not necessary to include `[WIP]` in commit messages, but if you do, please remove it before it gets merged.
 
-
 ## Design Documents
-Changes to BonnyCI should follow a design document. To propose a design document, open a pull requests to the [lore repository](https://github.com/BonnyCI/lore). BonnyCI contributors will review and debate the proposed document via pull request comments until the document is accepted. When the pull request is merged, development can begin.
 
+Changes to BonnyCI should follow a design document. To propose a design document, open a pull requests to the [lore repository](https://github.com/BonnyCI/lore). BonnyCI contributors will review and debate the proposed document via pull request comments until the document is accepted. When the pull request is merged, development can begin.
 
 Design documents exist in the [design documentation](designs) directory.

--- a/developers/contributing/designs/README.md
+++ b/developers/contributing/designs/README.md
@@ -1,4 +1,5 @@
 # Design Documents
 
 ## Table of Contents
-- [Github Pull Request Check and Gate](github-pr-check-gate.md)
+
+* [Github Pull Request Check and Gate](github-pr-check-gate.md)

--- a/developers/contributing/designs/github-pr-check-gate.md
+++ b/developers/contributing/designs/github-pr-check-gate.md
@@ -63,6 +63,7 @@ Example:
 The Gate Pipeline is the series of jobs that must occur prior to a Pull Request being merged. The Gate Pipeline is a queue of Pull Requests that can be tested together. Zuul builds the Gate Pipeline queue based on when Pull Requests are triggered and what jobs they share in the pipeline[1]. When a Pull Request passes the Gate Pipeline, it is automatically merged into the target branch. Therefore, the requirements for triggering the Gate Pipeline are more stringent than they are for the Check Pipeline.
 
 ![gate pipeline](github_gate_pipeline.png)
+
 ### Triggering the Gate Pipeline
 
 The Zuul server initiates the Gate Pipeline when it receives a GitHub event payload for the following events:
@@ -88,9 +89,9 @@ Once the jobs in the Gate Pipeline have completed, Zuul posts the following usin
 #### Passing the Gate Pipeline
 
 1. Zuul posts a new status for the commit set to `success`
-1. Zuul merges the Pull Request by making a call to the GitHub API
+2. Zuul merges the Pull Request by making a call to the GitHub API
 
 #### Failing the Gate Pipeline
 
 1. Zuul posts a new status for the commit set to `failure`
-1. Zuul posts a new Pull Request comment indicating the merge failed, (with a link to the logs URL from the job(s) executions)
+2. Zuul posts a new Pull Request comment indicating the merge failed, (with a link to the logs URL from the job(s) executions)

--- a/developers/dev-environment/macOS.md
+++ b/developers/dev-environment/macOS.md
@@ -1,9 +1,10 @@
 # Instructions for macOS
 
 Install required software:
-- [Homebrew](http://brew.sh/)
-- [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-- [Vagrant](https://www.vagrantup.com/downloads.html)
+
+* [Homebrew](http://brew.sh/)
+* [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+* [Vagrant](https://www.vagrantup.com/downloads.html)
 
 Install some basic command line tools and nodejs:
 


### PR DESCRIPTION
Fixing Markdown files to meet requirements imposed by new
markdownlint-cli configuration.

Required-By: #33
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>