### PR TITLE
Move hoist vagrant docs to lore

### DIFF
--- a/developers/README.md
+++ b/developers/README.md
@@ -4,7 +4,6 @@
 
 * [Development Environment](#development-environment)
   * [Virtual Machines](#virtual-machines)
-  * [Docker](#docker)
 * [Contributing](#contributing)
 * [IRC](#irc)
 
@@ -16,6 +15,44 @@ Supported development platforms:
 
 * [Ubuntu](dev-environment/ubuntu.md)
 * [Apple's macOS](dev-environment/macOS.md)
+
+### Virtual Machines
+
+You can test changes to BonnyCI locally by exercising some tools defined in [hoist](www.github.com/BonnyCI/hoist). Hoist is a set of ansible playbooks that automate the deployment of a BonnyCI environment. Be sure that you have completed the `Virtualization Tools` section of your OS's [Development Environment](#development-environment) page before proceeding.
+
+Clone hoist and navigate to its base directory:
+
+```shell
+$ git clone git@github.com:BonnyCI/hoist.git
+$ cd hoist
+```
+
+To perform a full deploy::
+
+```shell
+$ vagrant up
+```
+
+To redeploy just the nodepool VM::
+
+```shell
+$ vagrant destroy nodepool
+$ vagrant up nodepool
+```
+
+To inspect the zuul VM::
+
+```shell
+$ vagrant ssh zuul
+$ # netstat, tcpdump, tail logs, etc.
+$ logout
+```
+
+To tear down the entire stack when you're done::
+
+```shell
+$ vagrant destroy
+```
 
 ## Contributing
 


### PR DESCRIPTION
Since we're using lore as a central documentation repo, we should move
some of the currently existing stuff over here.

Resolves (partial): #1 #4 (step 2)

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>