### PR TITLE
Update dev-environment lore

### DIFF
--- a/developers/dev-environment/macOS.md
+++ b/developers/dev-environment/macOS.md
@@ -1,16 +1,19 @@
 # Instructions for macOS
 
-Install required software:
+## Table of Contents
 
-* [Homebrew](http://brew.sh/)
-* [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-* [Vagrant](https://www.vagrantup.com/downloads.html)
+* [Basic Tools](#basic-tools)
+* [Python Tools](#python-tools)
+* [Virtualization Tools](#virtualization-tools)
 
-Install some basic command line tools and nodejs:
+## Basic Tools
+
+Install [Homebrew](http://brew.sh/) to get a package manager.
+
+Install some basic command line tools:
 
 ```shell
 $ brew install coreutils
-$ brew install node
 ```
 
 You can get by with coreutils with prefixing commands you want with a `g`. For instance, `rm` would be `grm`. If you don't want to think about that too much, add the following to your `~/.bash_profile`:
@@ -19,6 +22,8 @@ You can get by with coreutils with prefixing commands you want with a `g`. For i
 export PATH=/usr/local/opt/coreutils/libexec/gnubin:/usr/local/sbin:$PATH
 export MANPATH=/usr/local/opt/coreutils/libexec/gnuman:$MANPATH
 ```
+
+## Python Tools
 
 Install the python package manager pip:
 
@@ -44,6 +49,10 @@ Enable virtualenvwrapper:
 ```shell
 $ source ~/.bash_profile
 ```
+
+## Virtualization Tools
+
+Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Vagrant](https://www.vagrantup.com/downloads.html) for running local virtual machines.
 
 Install [vagrant-hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager), and [vagrant-triggers](https://github.com/emyl/vagrant-triggers):
 

--- a/developers/dev-environment/ubuntu.md
+++ b/developers/dev-environment/ubuntu.md
@@ -1,22 +1,16 @@
 # Instructions for Ubuntu
 
+## Table of Contents
+
+* [Python Tools](#python-tools)
+* [Virtualization Tools](#virtualization-tools)
+
+## Python Tools
+
 Run the following to install most of the needed packages:
 
 ```shell
-$ sudo apt-get install build-essential libssl-dev libffi-dev python-dev python-pip python-software-properties vagrant virtualbox
-```
-
-Install [vagrant-hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager), and [vagrant-triggers](https://github.com/emyl/vagrant-triggers):
-
-```shell
-$ vagrant plugin install vagrant-hostmanager vagrant-triggers
-```
-
-Add the official nodejs ppa, then install nodejs and its package manager, npm:
-
-```shell
-$ curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
-$ sudo apt-get install nodejs
+$ sudo apt-get install build-essential libssl-dev libffi-dev python-dev python-pip python-software-properties
 ```
 
 Install ansible, setuptools, virtualenv and virtualenvwrapper:
@@ -36,4 +30,18 @@ Activate virtualenvwrapper:
 
 ```shell
 $ source ~/.bashrc
+```
+
+## Virtualization Tools
+
+Install [VirtualBox](https://www.virtualbox.org) and [Vagrant](https://www.vagrantup.com) for running local virtual machines:
+
+```shell
+$ sudo apt-get install vagrant virtualbox
+```
+
+Install [vagrant-hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager), and [vagrant-triggers](https://github.com/emyl/vagrant-triggers):
+
+```shell
+$ vagrant plugin install vagrant-hostmanager vagrant-triggers
 ```


### PR DESCRIPTION
* Separate steps into grouped sections with labels. This will make it
  easier for us to refer to specific sections of the instructions.

* Remove nodejs install steps. Instructing our devs to install node for
  the purpose of linting their doc changes locally seems unnecessary.

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>