### PR TITLE
Fix in-page anchors in admin TOC

### DIFF
--- a/admins/README.md
+++ b/admins/README.md
@@ -11,16 +11,16 @@ The BonnyCI system is made up of the following components:
 
 * [Bastion](#bastion)
 * [Zuul](#zuul)
-  * [Server](#server)
-  * [Launcher](#launcher)
-  * [Merger](#merger)
-  * [Web App](#web app)
+  * [Server](#zuul-server)
+  * [Launcher](#zuul-launcher)
+  * [Merger](#zuul-merger)
+  * [Web App](#zuul-web-app)
 * [Nodepool](#nodepool)
-  * [Server](#server)
-  * [Builder](#builder)
-  * [Launcher](#launcher)
-  * [Deleter](#deleter)
-* [Logs host](#logs host)
+  * [Server](#nodepool-server)
+  * [Builder](#nodepool-builder)
+  * [Launcher](#nodepool-launcher)
+  * [Deleter](#nodepool-deleter)
+* [Logs host](#logs-host)
 
 ### Bastion
 


### PR DESCRIPTION
Seems that the links in the Admin TOC didn't point to the generated
header anchors.

Signed-off-by: Bradon Kanyid <rattboi@gmail.com>