### PR TITLE
Update test scripts for BonnyCI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,13 @@
 ---
+dist: trusty
+sudo: required
+
 cache:
   directories:
     - "$(npm config get prefix)/bin"
 
 language: python
 python: '2.7'
-
-addons:
-  apt:
-    sources:
-      - debian-sid
-    packages:
-      - shellcheck
 
 matrix:
   fast_finish: true
@@ -25,9 +21,6 @@ env:
 install:
   - nvm install stable
   - nvm use stable
-  - npm install -g markdownlint-cli textlint textlint-rule-alex
-    textlint-rule-common-misspellings textlint-rule-no-dead-link
-    textlint-rule-no-empty-section textlint-rule-rousseau textlint-rule-no-todo
 
 script: "$TEST_RUN"
 

--- a/tests/markdownlint-cli-test.sh
+++ b/tests/markdownlint-cli-test.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+npm install -g markdownlint-cli
+
 markdownlint -c .markdownlint.js .

--- a/tests/shellcheck-test.sh
+++ b/tests/shellcheck-test.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+sudo apt-get install -y shellcheck
+
 find . -name '*.sh' -print0 | xargs -n1 -0 shellcheck -s bash

--- a/tests/textlint-test.sh
+++ b/tests/textlint-test.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+npm install -g textlint textlint-rule-alex textlint-rule-common-misspellings textlint-rule-no-dead-link textlint-rule-no-empty-section textlint-rule-rousseau textlint-rule-no-todo
+
 find . -name '*.md' -print0 | xargs -n1 -0 textlint -c .textlintrc.js -f pretty-error


### PR DESCRIPTION
Previously, all additional software was being installed via the Travis
CI job, and not the scripts it runs. For the BonnyCI integration
added in BonnyCI/hoist#87 to work as expected, we are adding the
software installations to the scripts themselves. With this change,
Travis will require Trusty and sudo access.

Related-Issue: BonnyCI/lore#44
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>