### PR TITLE
Make dead link warnings non-voting

### DIFF
--- a/.textlintrc.js
+++ b/.textlintrc.js
@@ -8,6 +8,7 @@ module.exports = {
       "ignore": []
     },
     "no-dead-link": {
+      "severity" : "warning"
     },
     "no-empty-section": {
     },


### PR DESCRIPTION
Dead link warnings are nice, but right now we have install steps which
rely on private links.

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>