### PR TITLE
Fix npm installs needing sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ env:
   - TEST_RUN="tests/signed-off-by-test.sh"
 
 install:
-  - nvm install stable
-  - nvm use stable
+  - nvm deactivate
+  - curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
+  - sudo apt-get install -y nodejs
 
 script: "$TEST_RUN"
 

--- a/tests/markdownlint-cli-test.sh
+++ b/tests/markdownlint-cli-test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-npm install -g markdownlint-cli
+sudo npm install -g markdownlint-cli
 
 markdownlint -c .markdownlint.js .

--- a/tests/textlint-test.sh
+++ b/tests/textlint-test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-npm install -g textlint textlint-rule-alex textlint-rule-common-misspellings textlint-rule-no-dead-link textlint-rule-no-empty-section textlint-rule-rousseau textlint-rule-no-todo
+sudo npm install -g textlint textlint-rule-alex textlint-rule-common-misspellings textlint-rule-no-dead-link textlint-rule-no-empty-section textlint-rule-rousseau textlint-rule-no-todo
 
 find . -name '*.md' -print0 | xargs -n1 -0 textlint -c .textlintrc.js -f pretty-error


### PR DESCRIPTION
The npm dependencies needed by a few of the tests can't install globally
because they don't have rights to the install path. Sudo fixes this.

Signed-off-by: Bradon Kanyid <rattboi@gmail.com>