### PR TITLE
Use sed to change node to nodejs in markdownlint

### DIFF
--- a/tests/markdownlint-cli-test.sh
+++ b/tests/markdownlint-cli-test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-npm install -g markdownlint-cli
+sudo npm install -g markdownlint-cli
+
+# Fix markdownlint's environmental janky-ness
+sudo sed 's/\#\!\/usr\/bin\/env node/\#\!\/usr\/bin\/env nodejs/' /usr/local/bin/markdownlint
 
 markdownlint -c .markdownlint.js .


### PR DESCRIPTION
Because Ubuntu does not have an environment called `node`,
`markdownlint` is now being pointed to `nodejs`.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>