### PR TITLE
Set ALEX to allow certain words

### DIFF
--- a/.textlintrc.js
+++ b/.textlintrc.js
@@ -2,7 +2,7 @@
 module.exports = {
   "rules": {
     "alex": {
-      "severity" : "warning"
+      "allow": ["failed", "failure", "host-hostess", "hostesses-hosts", "slave"]
     },
     "common-misspellings": {
       "ignore": []


### PR DESCRIPTION
Previously, ALEX was erroring on a few terms that are required in our
lore, but may be offensive in a different setting (fail{ed,ure},
host{est,sets,s}, and execute). As a quick work around, we had set the
rule to being a warning, but this is unideal since we want it to catch
other potentially offensive language.

Now, Alex allows those words.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>