### PR TITLE
Remove `textlint` test from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
 
 env:
   - TEST_RUN="tests/markdownlint-cli-test.sh"
-  - TEST_RUN="tests/textlint-test.sh"
   - TEST_RUN="tests/shellcheck-test.sh"
   - TEST_RUN="tests/signed-off-by-test.sh"
 


### PR DESCRIPTION
Discussion on BonnyCI/lore#54 led to the decision that `textlint` would
be removed from the CI sysytems.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>